### PR TITLE
map os.tmpDir function

### DIFF
--- a/handlers/multipart.js
+++ b/handlers/multipart.js
@@ -10,6 +10,14 @@ var formidable = require('formidable');
 var _ = require('lodash');
 var semver = require('semver');
 var LangUtils = require('@themost/common/utils').LangUtils;
+// DEP0022: os.tmpDir()
+// The os.tmpDir() API was deprecated in Node.js 7.0.0 and has since been removed. Please use os.tmpdir() instead.
+// v14.0.0 end-of-life
+// v7.0.0 deprecation
+// Solution: map os.tmpDir() used by formidable to os.tmpdir()
+if (typeof os.tmpDir === 'undefined' && typeof os.tmpdir === 'function') {
+    os.tmpDir = os.tmpdir;
+}
 
 if (semver.gte(process.versions.node, "6.0.0")) {
     var multipart_parser = require('formidable/lib/multipart_parser'),

--- a/handlers/post.js
+++ b/handlers/post.js
@@ -9,7 +9,15 @@
 var formidable = require('formidable');
 var _ = require('lodash');
 var TraceUtils = require('@themost/common/utils').TraceUtils;
-
+var os = require('os');
+// DEP0022: os.tmpDir()
+// The os.tmpDir() API was deprecated in Node.js 7.0.0 and has since been removed. Please use os.tmpdir() instead.
+// v14.0.0 end-of-life
+// v7.0.0 deprecation
+// Solution: map os.tmpDir() used by formidable to os.tmpdir()
+if (typeof os.tmpDir === 'undefined' && typeof os.tmpdir === 'function') {
+    os.tmpDir = os.tmpdir;
+}
 /**
  * @class UnknownValue
  * @constructor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/web",
-  "version": "2.5.12",
+  "version": "2.5.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/web",
-  "version": "2.5.12",
+  "version": "2.5.13",
   "description": "MOST Web Framework 2.0 - Web Server Module",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR closes #15 by mapping the deprecated function `os.tmpDir()` to `os.tmpdir()`.